### PR TITLE
Session expire fix

### DIFF
--- a/src/web/assets/js/alaska_main.js
+++ b/src/web/assets/js/alaska_main.js
@@ -100,6 +100,12 @@ function _showErrorModal(message) {
 
   if (typeof(message) == 'object') {
     output.text(JSON.stringify(message));
+
+    // Logout if the token has expired.
+    if (message.code == 209) {
+      Parse.User.logOut();
+      window.location.reload(false);
+    }
   } else {
     output.text(message);
   }


### PR DESCRIPTION
Fix blocking bug where if the session token is expired, refreshing the page doesn't ask the user to log in. Instead, it continuously displays the session token expired error.